### PR TITLE
Update index.js to fix translation requests originating from China

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,14 +73,24 @@ var window = {
     TKK: config.get('TKK') || '0'
 };
 
+var url = config.get('url');
+
 function updateTKK() {
     return new Promise(function (resolve, reject) {
         var now = Math.floor(Date.now() / 3600000);
 
-        if (Number(window.TKK.split('.')[0]) === now) {
+        if (url && Number(window.TKK.split('.')[0]) === now) {
             resolve();
         } else {
-            got('https://translate.google.com').then(function (res) {
+            const reqs = [
+                got('https://translate.google.com'),
+                got('https://translate.google.cn')
+            ];
+            Promise.race(reqs).then(function (res) {
+                reqs.forEach(function (res) {
+                    res.cancel();
+                });
+
                 var matches = res.body.match(/tkk:\s?'(.+?)'/i);
 
                 if (matches) {


### PR DESCRIPTION
Updates the index.js to resolve an issue where the Chinese can't use this library nor it's parent to translate using code from an old PR to this library's parent repo. This is part of the PR from https://github.com/vitalets/google-translate-api/pull/5 fixing issues https://github.com/vitalets/google-translate-api/issues/4, https://github.com/matheuss/google-translate-api/issues/59, https://github.com/matheuss/google-translate-api/issues/60, https://github.com/matheuss/google-translate-api/issues/62, https://github.com/matheuss/google-translate-api/issues/68, and https://github.com/matheuss/google-translate-token/issues/10 over there, using code from an old PR sent to the unmaintained upstream (https://github.com/matheuss/google-translate-token/pull/11, to be exact).