### PR TITLE
Update index.js to allow for any language URL to be used

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function updateTKK() {
         if (Number(window.TKK.split('.')[0]) === now) {
             resolve();
         } else {
-            got('https://translate.google.'+{tld}).then(function (res) {
+            got('https://translate.google.'+opts.tld).then(function (res) {
                 var matches = res.body.match(/tkk:\s?'(.+?)'/i);
 
                 if (matches) {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function updateTKK() {
         if (Number(window.TKK.split('.')[0]) === now) {
             resolve();
         } else {
-            got('https://translate.google.com').then(function (res) {
+            got('https://translate.google.'+{tld}).then(function (res) {
                 var matches = res.body.match(/tkk:\s?'(.+?)'/i);
 
                 if (matches) {


### PR DESCRIPTION
Update index.js to allow for v2 of the URL code (works in an even better way than how PR #1 did it to begin with, fixing the issues documented there. It's now tied to PR https://github.com/vitalets/google-translate-api/pull/7).